### PR TITLE
Expose Exchange Internals to Improve Developer Experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Jackrabbit
 
-This is a fork of [hunterloftis/jackrabbit].
-
-[![CircleCI](https://circleci.com/gh/pagerinc/jackrabbit.svg?style=svg)](https://circleci.com/gh/pagerinc/jackrabbit)
+This is a fork of [pagerinc/jackrabbit], which is a fork of [hunterloftis/jackrabbit].
 
 Jackrabbit is a very opinionated abstraction built on top of `amqplib` focused
 on usability and implementing several messaging patterns on RabbitMQ.
@@ -13,7 +11,7 @@ on usability and implementing several messaging patterns on RabbitMQ.
 // producer.js
 'use strict';
 
-const jackrabbit = require('@pager/jackrabbit');
+const jackrabbit = require('tibbarkcaj');
 const rabbit = jackrabbit(process.env.RABBIT_URL);
 
 rabbit
@@ -26,7 +24,7 @@ rabbit
 // consumer.js
 'use strict';
 
-const jackrabbit = require('@pager/jackrabbit');
+const jackrabbit = require('tibbarkcaj');
 const rabbit = jackrabbit(process.env.RABBIT_URL);
 
 rabbit
@@ -44,7 +42,7 @@ function onMessage(data) {
 ```js
 'use strict';
 
-const jackrabbit = require('@pager/jackrabbit');
+const jackrabbit = require('tibbarkcaj');
 const rabbit = jackrabbit(process.env.RABBIT_URL);
 
 rabbit
@@ -61,13 +59,13 @@ rabbit
 
 ## More Examples
 
-For now, the best usage help is can be found in [examples](https://github.com/pagerinc/jackrabbit/tree/master/examples),
+For now, the best usage help is can be found in [examples](https://github.com/akamaozu/tibbarkcaj/tree/master/examples),
 which map 1-to-1 with the official RabbitMQ tutorials.
 
 ## Installation
 
 ```
-npm install --save @pager/jackrabbit
+npm install --save tibbarkcaj
 ```
 
 ## Tests
@@ -80,6 +78,7 @@ to run them:
 $ docker-compose up
 ```
 
+[pagerinc/jackrabbit]: https://github.com/pagerinc/jackrabbit
 [hunterloftis/jackrabbit]: https://github.com/hunterloftis/jackrabbit
 
 ## Reconnection

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -431,6 +431,24 @@ const exchange = (name, type, exchangeOptions) => {
         });
     };
 
+    const getInternals = () => {
+
+        const internals = {
+            // amqplib instances
+            connection,
+            channel,
+
+            // internal state
+            ready,
+            blocked,
+            connecting,
+            publishing,
+            replyQueueConfigured,
+        }
+
+        return internals
+    }
+
     const emitter = Extend(new EventEmitter(), {
         name,
         type,
@@ -441,7 +459,8 @@ const exchange = (name, type, exchangeOptions) => {
         publishSafe,
         getWritableStream,
         rpcClient,
-        rpcServer
+        rpcServer,
+        getInternals,
     });
 
     return emitter;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@pager/jackrabbit",
-  "version": "5.4.4",
+  "name": "tibbarkcaj",
+  "version": "1.0.0",
   "description": "Easy RabbitMQ for node",
   "keywords": [
     "amqp",
@@ -17,10 +17,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/pagerinc/jackrabbit.git"
+    "url": "git://github.com/akamaozu/tibbarkcaj.git"
   },
-  "homepage": "https://github.com/pagerinc/jackrabbit",
-  "bugs": "https://github.com/pagerinc/jackrabbit/issues",
+  "homepage": "https://github.com/akamaozu/tibbarkcaj",
+  "bugs": "https://github.com/akamaozu/tibbarkcaj/issues",
   "main": "lib/jackrabbit.js",
   "renovate": {
     "extends": [
@@ -34,7 +34,7 @@
     "node": ">= v10.18.0"
   },
   "license": "MIT",
-  "author": "Pager Developers <engineering@pager.com>",
+  "author": "akamaozu <uzo@designbymobius.ca>",
   "contributors": [
     "Pager Developers <engineering@pager.com>",
     "Hunter Loftis <hunter@hunterloftis.com>"


### PR DESCRIPTION
Situation
---

- rabbitmq sends messages to exchanges using a connection + channel system
- jackrabbit communicates with rabbitmq instances using amqplib's connection and channel api
- **jackrabbit's exchange does not expose amqplib's channel**

Problem
---

- **jackrabbit users are unable to handle channel-specific events / errors**
(see: https://amqp-node.github.io/amqplib/channel_api.html#channel_events)

Proposal
---
- expose amqplib's channel so jackrabbit developers can go deeper than jackrabbit's interface allows, if need be
- use a similar api as jackrabbit client instance
(see: https://github.com/pagerinc/jackrabbit/blob/7fb2afc5ffbf71c330e88c877a7735b71d1c61eb/lib/jackrabbit.js#L205-L214)

