### PR TITLE
Improve Exchange Tests

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -7,10 +7,37 @@ const { Writable } = require('stream');
 
 const Queue = require('./queue');
 
-const DEFAULT_EXCHANGES = {
-    'direct': 'amq.direct',
-    'fanout': 'amq.fanout',
-    'topic': 'amq.topic'
+const EXCHANGE_TYPES = {
+    'direct': {
+        type: 'direct',
+        predeclared: [
+            '',
+            'amq.direct',
+        ],
+        default_name: 'amq.direct',
+    },
+    'fanout': {
+        type: 'fanout',
+        predeclared: [
+            'amq.fanout',
+        ],
+        default_name: 'amq.fanout',
+    },
+    'headers': {
+        type: 'headers',
+        predeclared: [
+            'amq.headers',
+            'amq.match',
+        ],
+        default_name: 'amq.headers',
+    },
+    'topic': {
+        type: 'topic',
+        predeclared: [
+            'amq.topic',
+        ],
+        default_name: 'amq.topic',
+    },
 };
 
 const DEFAULT_EXCHANGE_OPTIONS = {
@@ -41,7 +68,7 @@ const DEFAULT_RPC_CLIENT_OPTIONS = {
 
 const isDefault = (name, type) => {
 
-    return DEFAULT_EXCHANGES[type] === name;
+    return EXCHANGE_TYPES[type].predeclared.indexOf( name ) > -1;
 };
 
 const isNameless = (name) => {
@@ -55,9 +82,11 @@ const exchange = (name, type, exchangeOptions) => {
         throw new Error('missing exchange type');
     }
 
-    if (!isNameless(name)) {
-        name = name || DEFAULT_EXCHANGES[type];
-        if (!name) {
+    if (!name && !isNameless(name)) {
+        if (EXCHANGE_TYPES[type]) {
+            name = EXCHANGE_TYPES[type].default_name;
+        }
+        else {
             throw new Error('missing exchange name');
         }
     }
@@ -396,13 +425,19 @@ const exchange = (name, type, exchangeOptions) => {
         channel.once('close', bail.bind(this, new Error('channel closed')));
         channel.on('drain', onDrain);
         emitter.emit('connected');
-        if (isDefault(emitter.name, DEFAULT_EXCHANGES[emitter.type]) || isNameless(emitter.name)) {
+        if (isDefault(emitter.name, emitter.type)) {
             onExchange(undefined, {
                 exchange: emitter.name
             });
         }
         else {
-            channel.assertExchange(emitter.name, emitter.type, emitter.options, onExchange);
+            try {
+                channel.assertExchange(emitter.name, emitter.type, emitter.options, onExchange);
+            }
+
+            catch (assertExchangeError) {
+                onExchange( assertExchangeError )
+            }
         }
     };
 

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -140,7 +140,7 @@ describe('exchange', () => {
         truthy_typeof_example_keys.forEach( typeof_key => {
 
             if ( valid_typeof_exchange_names.indexOf( typeof_key ) === -1 ) {
-                it(`closes exchange if typeof exchange name is "${ typeof_key }"`, (done) => {
+                it(`closes exchange with TypeError if typeof exchange name is "${ typeof_key }"`, (done) => {
 
                     Exchange(typeof_examples_map[ typeof_key ].example, 'direct')
                         .connect(connection)

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -90,7 +90,7 @@ describe('exchange', () => {
                 .once('connected', done);
         });
 
-        const typeof_examples_map = {
+        const typeofExamplesMap = {
             string: {
                 typeof: 'string',
                 example: 'hello world',
@@ -129,35 +129,40 @@ describe('exchange', () => {
             },
         }
 
-        const valid_typeof_exchange_names = [ 'string' ]
+        const validTypeofExchangeNames = [ 'string' ]
 
-        const typeof_example_keys = Object.keys( typeof_examples_map )
+        const typeofExampleKeys = Object.keys( typeofExamplesMap )
 
-        const truthy_typeof_example_keys = typeof_example_keys.filter( key => {
-            return (typeof_examples_map[ key ].example && 'truthy') === 'truthy'
+        const truthyTypeofExampleKeys = typeofExampleKeys.filter( key => {
+            return (typeofExamplesMap[ key ].example && 'truthy') === 'truthy'
         })
 
-        truthy_typeof_example_keys.forEach( typeof_key => {
-
-            if ( valid_typeof_exchange_names.indexOf( typeof_key ) === -1 ) {
-                it(`closes exchange with TypeError if typeof exchange name is "${ typeof_key }"`, (done) => {
-
-                    Exchange(typeof_examples_map[ typeof_key ].example, 'direct')
+        truthyTypeofExampleKeys.forEach( typeofKey => {
+            if (validTypeofExchangeNames.indexOf( typeofKey ) === -1) {
+                it(`closes exchange with TypeError if typeof exchange name is "${ typeofKey }"`, (done) => {
+                    Exchange(typeofExamplesMap[ typeofKey ].example, 'direct')
                         .connect(connection)
                         .once('close', (error) => {
-                            Assert( error instanceof TypeError, 'expected type error on Exchange close' )
-                            done()
+                            Assert(error instanceof TypeError, 'expected type error on Exchange close');
+                            done();
                         });
                 });
             }
 
             else {
-                it(`emits a "ready" event if typeof exchange name is "${ typeof_key }"`, (done) => {
-
-                    Exchange(typeof_examples_map[ typeof_key ].example, 'direct')
+                it(`emits a "ready" event if typeof exchange name is "${ typeofKey }"`, (done) => {
+                    const exchangeName = typeofExamplesMap[ typeofKey ].example
+                    const exchange = Exchange(exchangeName, 'direct')
                         .connect(connection)
                         .once('ready', () => {
-                            done()
+                            const { channel } = exchange.getInternals()
+                            channel.deleteExchange(exchangeName, {}, (error) => {
+                                if (error) {
+                                    console.log(`WARN: failed to delete exchange "${ exchangeName }" -- ${ error.stack ?? error.message ?? 'unspecified error' }`);
+                                }
+
+                                done();
+                            });
                         });
                 });
             }

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -89,6 +89,79 @@ describe('exchange', () => {
                 .connect(connection)
                 .once('connected', done);
         });
+
+        const typeof_examples_map = {
+            string: {
+                typeof: 'string',
+                example: 'hello world',
+            },
+            number: {
+                typeof: 'number',
+                example: 100_000,
+            },
+            boolean: {
+                typeof: 'boolean',
+                example: true,
+            },
+            bigint: {
+                typeof: 'bigint',
+                example: 1n,
+            },
+            symbol: {
+                typeof: 'symbol',
+                example: Symbol(),
+            },
+            null: {
+                typeof: 'null',
+                example: null,
+            },
+            undefined: {
+                typeof: 'undefined',
+                example: undefined,
+            },
+            object: {
+                typeof: 'object',
+                example: { id: 'hello world' },
+            },
+            function: {
+                typeof: 'function',
+                example: () => 'hello world',
+            },
+        }
+
+        const valid_typeof_exchange_names = [ 'string' ]
+
+        const typeof_example_keys = Object.keys( typeof_examples_map )
+
+        const truthy_typeof_example_keys = typeof_example_keys.filter( key => {
+            return (typeof_examples_map[ key ].example && 'truthy') === 'truthy'
+        })
+
+        truthy_typeof_example_keys.forEach( typeof_key => {
+
+            if ( valid_typeof_exchange_names.indexOf( typeof_key ) === -1 ) {
+                it(`closes exchange if typeof exchange name is "${ typeof_key }"`, (done) => {
+
+                    Exchange(typeof_examples_map[ typeof_key ].example, 'direct')
+                        .connect(connection)
+                        .once('close', (error) => {
+                            Assert( error instanceof TypeError, 'expected type error on Exchange close' )
+                            done()
+                        });
+                });
+            }
+
+            else {
+                it(`emits a "ready" event if typeof exchange name is "${ typeof_key }"`, (done) => {
+
+                    Exchange(typeof_examples_map[ typeof_key ].example, 'direct')
+                        .connect(connection)
+                        .once('ready', () => {
+                            done()
+                        });
+                });
+            }
+        });
     });
 
     describe('#getWritableStream', () => {

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -54,11 +54,28 @@ describe('exchange', () => {
                 });
             });
 
+            describe('and a headers type', () => {
+
+                const e = Exchange(undefined, 'headers');
+                it('receives the default name amq.headers', () => {
+
+                    Assert.equal(e.name, 'amq.headers');
+                });
+            });
+
             describe('and no type', () => {
 
                 it('throws an error', () => {
 
                     Assert.throws(Exchange.bind(this, undefined, undefined), 'missing exchange type');
+                });
+            });
+
+            describe('and non-default (custom) type', () => {
+
+                it('throws an error', () => {
+
+                    Assert.throws(Exchange.bind(this, undefined, 'random'), 'missing exchange name');
                 });
             });
         });


### PR DESCRIPTION
- verify jackrabbit behavior based on typeof variable passed as exchange name
- verify behavior when exchange is created with no name for "headers" exchange
- verify behavior when exchange is created with no name for custom exchanges
- **catch client errors when asserting exchanges and pass to onExchange callback**